### PR TITLE
feat: support Dawarich API imports

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.venv
+.venv*/
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+.env
+*.db
+*.sqlite
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 This application automates the process of downloading GPX activity files from Garmin Connect and uploading them to a Dawarich instance.
 
 ## Tested Dawarich
-**Works with Dawarich 1.3.1**
+**Works with Dawarich 1.3.1 using legacy email/password upload and Dawarich 1.3.4+ using API-key upload.**
 - Updates to the Dawarich app might break the upload (import) process.
-- By default, the application will only work with tested versions of Dawarich. This can be changed in settings.
+- By default, the legacy browser-login upload path will only work with tested versions of Dawarich. This can be changed in settings.
+- The `DAWARICH_API_KEY` upload path uses Dawarich's `/api/v1/imports` endpoint, which requires Dawarich 1.3.4 or newer and works with OIDC-only Dawarich setups.
 
 ## Support
 ##### Here is a link in case you want to leave a tip.
@@ -115,6 +116,15 @@ environment:
     POSTGRES_DB: "your_db_name"
     POSTGRES_HOST: "db" # Often the service name in docker-compose
 ```
+
+## Dawarich Upload Modes
+
+This app can upload GPX files to Dawarich in two ways:
+
+1. **API-key upload (recommended)**: Set `DAWARICH_API_KEY`. This uses `POST /api/v1/imports`, requires Dawarich 1.3.4 or newer, and is the right option for OIDC-only Dawarich setups where `/users/sign_in` is not available.
+2. **Legacy browser-login upload**: Set `DAWARICH_EMAIL` and `DAWARICH_PASSWORD` without `DAWARICH_API_KEY`. This keeps the older form-login/direct-upload flow for older Dawarich instances that do not have the import API.
+
+If `DAWARICH_API_KEY` is configured, it takes precedence over the legacy email/password upload flow.
 
 ## Database
 - The application will automatically use a local **LiteFS (SQLite)** database located in the `/garmin` volume if PostgreSQL environment variables are not fully provided.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This application automates the process of downloading GPX activity files from Ga
 *   **Historical Download**: A "Custom Check" feature allows downloading historical data for a specified date range, with a configurable delay to avoid rate-limiting.
 *   **Responsive Web UI**: A clean web interface that works on both desktop and mobile devices for viewing records and managing the application.
 *   **Intelligent Downloading**: Skips activities that have already been downloaded or do not contain any GPS location data.
-*   **Robust Uploading**: Simulates browser behavior to robustly upload GPX files to Dawarich's direct upload endpoint.
+*   **Robust Uploading**: Uses Dawarich's API-key import endpoint when `DAWARICH_API_KEY` is configured (works with OIDC-only Dawarich setups), with the legacy browser upload flow as a fallback.
 *   **Connection & Version Checks**: Performs pre-flight checks for Dawarich connection, credentials, and version compatibility to prevent errors.
 *   **Persistent Database**: Uses PostgreSQL or LiteFS (SQLite) to store a record of all downloaded files and their upload status.
 *   **GeoPulse Integration**: Optionally copies downloaded GPX files to a GeoPulse-compatible directory for additional location processing.
@@ -92,9 +92,13 @@ environment:
     # GARMIN_PASSWORD: "your_garmin_password"
 
     # Dawarich Instance Details
+    DAWARICH_HOST: "https://dawarich.example.com"
+    # Recommended for Dawarich 1.3.4+ and required when Dawarich uses OIDC-only login.
+    # The API key can be found in your Dawarich account settings.
+    DAWARICH_API_KEY: "your_dawarich_api_key"
+    # Legacy browser-login fallback (only needed if you do not use DAWARICH_API_KEY)
     DAWARICH_EMAIL: "your_dawarich_email@example.com"
     DAWARICH_PASSWORD: "your_dawarich_password"
-    DAWARICH_HOST: "https://dawarich.example.com"
 
     # Garmin activity exclusion list (optional, Python list format)
     # Example: EXCLUDE: "['Virtual Ride', 'Indoor Cycling']"
@@ -146,9 +150,12 @@ services:
       # GARMIN_EMAIL: "email@example.com"
       # GARMIN_PASSWORD: "your_garmin_password"
       EXCLUDE: "['Indoor Rowing', 'Indoor Cycling']"
-      DAWARICH_EMAIL: "email@example.com"
-      DAWARICH_PASSWORD: "ABCDabcdd123"
       DAWARICH_HOST: "https://dawarich.example.com"
+      # Recommended for Dawarich 1.3.4+ and required for OIDC-only Dawarich.
+      DAWARICH_API_KEY: "your_dawarich_api_key"
+      # Legacy browser-login fallback (only needed without DAWARICH_API_KEY)
+      # DAWARICH_EMAIL: "email@example.com"
+      # DAWARICH_PASSWORD: "ABCDabcdd123"
       
       # Optional GeoPulse Integration
       # GEOPULSE_ENABLE: "true"

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 This application automates the process of downloading GPX activity files from Garmin Connect and uploading them to a Dawarich instance.
 
 ## Tested Dawarich
-**Works with Dawarich 1.3.1 using legacy email/password upload and Dawarich 1.3.4+ using API-key upload.**
+**Works with Dawarich 1.3.4 using API-key upload.**
 - Updates to the Dawarich app might break the upload (import) process.
-- By default, the legacy browser-login upload path will only work with tested versions of Dawarich. This can be changed in settings.
-- The `DAWARICH_API_KEY` upload path uses Dawarich's `/api/v1/imports` endpoint, which requires Dawarich 1.3.4 or newer and works with OIDC-only Dawarich setups.
+- This fork uses Dawarich's `/api/v1/imports` endpoint and requires `DAWARICH_API_KEY`.
+- Legacy browser-login/email-password upload is no longer supported.
 
 ## Support
 ##### Here is a link in case you want to leave a tip.
@@ -30,8 +30,8 @@ This application automates the process of downloading GPX activity files from Ga
 *   **Historical Download**: A "Custom Check" feature allows downloading historical data for a specified date range, with a configurable delay to avoid rate-limiting.
 *   **Responsive Web UI**: A clean web interface that works on both desktop and mobile devices for viewing records and managing the application.
 *   **Intelligent Downloading**: Skips activities that have already been downloaded or do not contain any GPS location data.
-*   **Robust Uploading**: Uses Dawarich's API-key import endpoint when `DAWARICH_API_KEY` is configured (works with OIDC-only Dawarich setups), with the legacy browser upload flow as a fallback.
-*   **Connection & Version Checks**: Performs pre-flight checks for Dawarich connection, credentials, and version compatibility to prevent errors.
+*   **Robust Uploading**: Uses Dawarich's API-key import endpoint (works with OIDC-only Dawarich setups).
+*   **Connection Checks**: Performs pre-flight checks for Dawarich host, API key, and import API availability.
 *   **Persistent Database**: Uses PostgreSQL or LiteFS (SQLite) to store a record of all downloaded files and their upload status.
 *   **GeoPulse Integration**: Optionally copies downloaded GPX files to a GeoPulse-compatible directory for additional location processing.
 
@@ -94,12 +94,9 @@ environment:
 
     # Dawarich Instance Details
     DAWARICH_HOST: "https://dawarich.example.com"
-    # Recommended for Dawarich 1.3.4+ and required when Dawarich uses OIDC-only login.
+    # Required for Dawarich 1.3.4 API upload.
     # The API key can be found in your Dawarich account settings.
     DAWARICH_API_KEY: "your_dawarich_api_key"
-    # Legacy browser-login fallback (only needed if you do not use DAWARICH_API_KEY)
-    DAWARICH_EMAIL: "your_dawarich_email@example.com"
-    DAWARICH_PASSWORD: "your_dawarich_password"
 
     # Garmin activity exclusion list (optional, Python list format)
     # Example: EXCLUDE: "['Virtual Ride', 'Indoor Cycling']"
@@ -117,14 +114,14 @@ environment:
     POSTGRES_HOST: "db" # Often the service name in docker-compose
 ```
 
-## Dawarich Upload Modes
+## Dawarich Upload
 
-This app can upload GPX files to Dawarich in two ways:
+This fork supports **Dawarich 1.3.4 API-key upload only**:
 
-1. **API-key upload (recommended)**: Set `DAWARICH_API_KEY`. This uses `POST /api/v1/imports`, requires Dawarich 1.3.4 or newer, and is the right option for OIDC-only Dawarich setups where `/users/sign_in` is not available.
-2. **Legacy browser-login upload**: Set `DAWARICH_EMAIL` and `DAWARICH_PASSWORD` without `DAWARICH_API_KEY`. This keeps the older form-login/direct-upload flow for older Dawarich instances that do not have the import API.
-
-If `DAWARICH_API_KEY` is configured, it takes precedence over the legacy email/password upload flow.
+- Set `DAWARICH_API_KEY`.
+- Uploads use `POST /api/v1/imports`.
+- This is suitable for OIDC-only Dawarich setups where `/users/sign_in` is not available.
+- Legacy `DAWARICH_EMAIL` / `DAWARICH_PASSWORD` browser-login upload is no longer supported.
 
 ## Database
 - The application will automatically use a local **LiteFS (SQLite)** database located in the `/garmin` volume if PostgreSQL environment variables are not fully provided.
@@ -149,7 +146,7 @@ Please support [`Dawarich`](https://github.com/Freika/dawarich).
 services:
   garmin-to-dawarich-sync:
     container_name: garmin-to-dawarich-sync
-    image: ghcr.io/pinionless/garmin-to-dawarich-sync:latest
+    image: ghcr.io/frankhommers/garmin-to-dawarich-sync:latest
     volumes:
       - ./garmin-to-dawarich-sync:/garmin
     environment:
@@ -161,11 +158,8 @@ services:
       # GARMIN_PASSWORD: "your_garmin_password"
       EXCLUDE: "['Indoor Rowing', 'Indoor Cycling']"
       DAWARICH_HOST: "https://dawarich.example.com"
-      # Recommended for Dawarich 1.3.4+ and required for OIDC-only Dawarich.
+      # Required for Dawarich 1.3.4 API upload.
       DAWARICH_API_KEY: "your_dawarich_api_key"
-      # Legacy browser-login fallback (only needed without DAWARICH_API_KEY)
-      # DAWARICH_EMAIL: "email@example.com"
-      # DAWARICH_PASSWORD: "ABCDabcdd123"
       
       # Optional GeoPulse Integration
       # GEOPULSE_ENABLE: "true"

--- a/app.py
+++ b/app.py
@@ -34,9 +34,10 @@ def create_app():
     app.config['DAWARICH_EMAIL'] = os.environ.get('DAWARICH_EMAIL')
     app.config['DAWARICH_PASSWORD'] = os.environ.get('DAWARICH_PASSWORD')
     app.config['DAWARICH_HOST'] = os.environ.get('DAWARICH_HOST')
+    app.config['DAWARICH_API_KEY'] = os.environ.get('DAWARICH_API_KEY')
     app.config['_DAWARICH_CONNECTION_STATUS'] = {'status': None, 'timestamp': None, 'message': '', 'version': None}
     app.config['CUSTOM_CHECK_TASK'] = {'thread': None, 'stop_event': None, 'status_message': 'Not running.'}
-    app.config['SAFE_VERSIONS'] = ['0.28.1', '0.29.1', '0.30.0', '0.30.1', '0.30.2', '1.3.1']
+    app.config['SAFE_VERSIONS'] = ['0.28.1', '0.29.1', '0.30.0', '0.30.1', '0.30.2', '1.3.1', '1.3.4']
 
     raw = os.environ.get('EXCLUDE', '[]')
     try:

--- a/app.py
+++ b/app.py
@@ -31,13 +31,11 @@ def create_app():
     # via the Settings page (supports 2FA/MFA).
     app.config['GARMIN_EMAIL'] = os.environ.get('GARMIN_EMAIL')
     app.config['GARMIN_PASSWORD'] = os.environ.get('GARMIN_PASSWORD')
-    app.config['DAWARICH_EMAIL'] = os.environ.get('DAWARICH_EMAIL')
-    app.config['DAWARICH_PASSWORD'] = os.environ.get('DAWARICH_PASSWORD')
     app.config['DAWARICH_HOST'] = os.environ.get('DAWARICH_HOST')
     app.config['DAWARICH_API_KEY'] = os.environ.get('DAWARICH_API_KEY')
     app.config['_DAWARICH_CONNECTION_STATUS'] = {'status': None, 'timestamp': None, 'message': '', 'version': None}
     app.config['CUSTOM_CHECK_TASK'] = {'thread': None, 'stop_event': None, 'status_message': 'Not running.'}
-    app.config['SAFE_VERSIONS'] = ['0.28.1', '0.29.1', '0.30.0', '0.30.1', '0.30.2', '1.3.1', '1.3.4']
+    app.config['SAFE_VERSIONS'] = ['1.3.4']
 
     raw = os.environ.get('EXCLUDE', '[]')
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ python-dotenv==1.2.2
 requests==2.32.5
 Werkzeug==3.1.6
 gunicorn==25.1.0
-git+https://github.com/cyberjunky/python-garminconnect.git@edcf79f776f9e24ee780e48a2f623b33ecfbfc5f
+git+https://github.com/cyberjunky/python-garminconnect.git@v0.3.4
 bs4==0.0.2
 APScheduler==3.11.2
 lxml==6.0.2

--- a/templates/index.html
+++ b/templates/index.html
@@ -178,10 +178,7 @@
             <label for="delete_old_gpx">Delete old GPX files after upload:</label>
             <input type="checkbox" id="delete_old_gpx" name="delete_old_gpx" value="true" {% if settings.delete_old_gpx %}checked{% endif %}>
         </div>
-        <div class="form-group">
-            <label for="ignore_safe_dawarich_versions">Ignore Dawarich safe versions check:</label>
-            <input type="checkbox" id="ignore_safe_dawarich_versions" name="ignore_safe_dawarich_versions" value="true" {% if settings.ignore_safe_dawarich_versions %}checked{% endif %}>
-        </div>
+
         <div class="form-group">
             <label for="manual_check_start_date">Manual Check Start Date:</label>
             <input type="date" id="manual_check_start_date" name="manual_check_start_date" value="{{ settings.manual_check_start_date.isoformat() if settings.manual_check_start_date }}">

--- a/tests/test_dawarich_api_upload.py
+++ b/tests/test_dawarich_api_upload.py
@@ -1,0 +1,77 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from flask import Flask
+
+import utils
+from models import db, UserSettings
+
+
+GPX_BYTES = b'''<?xml version="1.0"?><gpx><trk><trkseg><trkpt lat="1" lon="2" /></trkseg></trk></gpx>'''
+
+
+class DawarichApiUploadTest(unittest.TestCase):
+    def make_app(self, tmp_path, api_key="secret-key"):
+        app = Flask(__name__)
+        app.config.update(
+            TESTING=True,
+            SQLALCHEMY_DATABASE_URI=f"sqlite:///{tmp_path / 'test.db'}",
+            SQLALCHEMY_TRACK_MODIFICATIONS=False,
+            DAWARICH_HOST="https://dawarich.example.test/",
+            DAWARICH_API_KEY=api_key,
+            _DAWARICH_CONNECTION_STATUS={"status": None, "timestamp": None, "message": "", "version": None},
+        )
+        db.init_app(app)
+        with app.app_context():
+            db.create_all()
+            db.session.add(UserSettings(delete_old_gpx=False))
+            db.session.commit()
+        return app
+
+    def test_submit_location_data_uses_dawarich_import_api_when_api_key_is_configured(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            app = self.make_app(tmp_path)
+            gpx_path = tmp_path / "activity.gpx"
+            gpx_path.write_bytes(GPX_BYTES)
+
+            response = Mock(ok=True, status_code=201, text='{"id": 42}', json=lambda: {"id": 42})
+
+            with app.app_context(), patch.object(utils, "check_dawarich_connection", return_value=True), patch("utils.requests.post", return_value=response) as post:
+                self.assertTrue(utils.submit_location_data(str(gpx_path)))
+
+            post.assert_called_once()
+            url = post.call_args.args[0]
+            kwargs = post.call_args.kwargs
+            self.assertEqual(url, "https://dawarich.example.test/api/v1/imports")
+            self.assertEqual(kwargs["params"], {"api_key": "secret-key"})
+            self.assertIn("file", kwargs["files"])
+            uploaded_file = kwargs["files"]["file"]
+            self.assertEqual(uploaded_file[0], "activity.gpx")
+            self.assertIn(uploaded_file[2], ("application/gpx+xml", "application/octet-stream"))
+
+    def test_check_dawarich_connection_uses_api_key_without_form_credentials(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            app = self.make_app(tmp_path)
+            response = Mock(ok=True, status_code=200, text="[]")
+            response.raise_for_status = Mock()
+
+            with app.app_context(), patch("utils.requests.get", return_value=response) as get:
+                self.assertTrue(utils.check_dawarich_connection(force_check=True))
+
+            get.assert_called_once_with(
+                "https://dawarich.example.test/api/v1/imports",
+                params={"api_key": "secret-key", "per_page": 1},
+                timeout=10,
+            )
+            self.assertTrue(app.config["_DAWARICH_CONNECTION_STATUS"]["status"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dawarich_api_upload.py
+++ b/tests/test_dawarich_api_upload.py
@@ -73,6 +73,35 @@ class DawarichApiUploadTest(unittest.TestCase):
             )
             self.assertTrue(app.config["_DAWARICH_CONNECTION_STATUS"]["status"])
 
+    def test_check_dawarich_connection_requires_api_key(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            app = self.make_app(tmp_path, api_key=None)
+            app.config["DAWARICH_EMAIL"] = "legacy@example.test"
+            app.config["DAWARICH_PASSWORD"] = "legacy-password"
+
+            with app.test_request_context(), patch("utils.requests.Session") as session:
+                self.assertFalse(utils.check_dawarich_connection(force_check=True))
+
+            session.assert_not_called()
+            message = app.config["_DAWARICH_CONNECTION_STATUS"]["message"]
+            self.assertIn("DAWARICH_API_KEY is required", message)
+            self.assertIn("Dawarich 1.3.4", message)
+
+    def test_submit_location_data_does_not_fall_back_to_legacy_browser_upload(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            app = self.make_app(tmp_path, api_key=None)
+            app.config["DAWARICH_EMAIL"] = "legacy@example.test"
+            app.config["DAWARICH_PASSWORD"] = "legacy-password"
+            gpx_path = tmp_path / "activity.gpx"
+            gpx_path.write_bytes(GPX_BYTES)
+
+            with app.app_context(), patch.object(utils, "check_dawarich_connection", return_value=True), patch("utils.requests.Session") as session:
+                self.assertFalse(utils.submit_location_data(str(gpx_path)))
+
+            session.assert_not_called()
+
     def test_check_dawarich_connection_reports_version_requirement_when_api_endpoint_is_missing(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
@@ -86,8 +115,8 @@ class DawarichApiUploadTest(unittest.TestCase):
                 self.assertFalse(utils.check_dawarich_connection(force_check=True))
 
             message = app.config["_DAWARICH_CONNECTION_STATUS"]["message"]
-            self.assertIn("Dawarich 1.3.4 or newer", message)
-            self.assertIn("legacy email/password", message)
+            self.assertIn("Dawarich 1.3.4", message)
+            self.assertNotIn("legacy", message.lower())
 
 
 if __name__ == "__main__":

--- a/tests/test_dawarich_api_upload.py
+++ b/tests/test_dawarich_api_upload.py
@@ -20,6 +20,7 @@ class DawarichApiUploadTest(unittest.TestCase):
         app = Flask(__name__)
         app.config.update(
             TESTING=True,
+            SECRET_KEY="test-secret",
             SQLALCHEMY_DATABASE_URI=f"sqlite:///{tmp_path / 'test.db'}",
             SQLALCHEMY_TRACK_MODIFICATIONS=False,
             DAWARICH_HOST="https://dawarich.example.test/",
@@ -71,6 +72,22 @@ class DawarichApiUploadTest(unittest.TestCase):
                 timeout=10,
             )
             self.assertTrue(app.config["_DAWARICH_CONNECTION_STATUS"]["status"])
+
+    def test_check_dawarich_connection_reports_version_requirement_when_api_endpoint_is_missing(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            app = self.make_app(tmp_path)
+            response = Mock(ok=False, status_code=404, text="Not found")
+            response.raise_for_status.side_effect = utils.requests.exceptions.HTTPError(
+                "404 Client Error", response=response
+            )
+
+            with app.test_request_context(), patch("utils.requests.get", return_value=response):
+                self.assertFalse(utils.check_dawarich_connection(force_check=True))
+
+            message = app.config["_DAWARICH_CONNECTION_STATUS"]["message"]
+            self.assertIn("Dawarich 1.3.4 or newer", message)
+            self.assertIn("legacy email/password", message)
 
 
 if __name__ == "__main__":

--- a/utils.py
+++ b/utils.py
@@ -12,10 +12,9 @@ from garminconnect import (
     GarminConnectAuthenticationError,
     GarminConnectConnectionError,
     GarminConnectTooManyRequestsError,
+    HTTPError,
 )
-from garth.exc import GarthHTTPError
 from models import db, DownloadRecord, UserSettings
-import hashlib, base64
 import time # Added for sleep functionality
 import shutil
 
@@ -100,8 +99,6 @@ def check_dawarich_connection(force_check=False):
             return status_cache['status']
 
     host = (current_app.config.get('DAWARICH_HOST') or '').rstrip('/')
-    user = current_app.config.get('DAWARICH_EMAIL')
-    pwd = current_app.config.get('DAWARICH_PASSWORD')
     api_key = current_app.config.get('DAWARICH_API_KEY')
 
     if not host:
@@ -111,117 +108,42 @@ def check_dawarich_connection(force_check=False):
         status_cache.update({'status': False, 'timestamp': time.time(), 'message': msg, 'version': None})
         return False
 
-    if api_key:
-        imports_url = f'{host}/api/v1/imports'
-        try:
-            resp = requests.get(
-                imports_url,
-                params={'api_key': api_key, 'per_page': 1},
-                timeout=10,
-            )
-            resp.raise_for_status()
-            current_app.logger.info("Dawarich API connection check successful.")
-            status_cache.update({'status': True, 'timestamp': time.time(), 'message': '', 'version': None})
-            return True
-        except requests.exceptions.HTTPError as e:
-            status_code = e.response.status_code if e.response is not None else None
-            if status_code == 404:
-                msg = (
-                    "Dawarich API import endpoint not found. DAWARICH_API_KEY upload requires "
-                    "Dawarich 1.3.4 or newer; use legacy email/password upload on older Dawarich versions."
-                )
-            elif status_code in (401, 403):
-                msg = "Dawarich API connection failed: invalid API key or API access denied."
-            else:
-                msg = f"Dawarich API connection failed: HTTP error - {e}"
-            current_app.logger.error(msg)
-            flash(msg, 'error')
-            status_cache.update({'status': False, 'timestamp': time.time(), 'message': msg, 'version': None})
-            return False
-        except requests.exceptions.RequestException as e:
-            msg = f"Dawarich API connection failed: Network error - {e}"
-            current_app.logger.error(msg)
-            flash(msg, 'error')
-            status_cache.update({'status': False, 'timestamp': time.time(), 'message': msg, 'version': None})
-            return False
-
-    if not all([user, pwd]):
-        msg = "Dawarich connection failed: Email or password not configured. Set DAWARICH_API_KEY for OIDC/API upload."
+    if not api_key:
+        msg = "Dawarich connection failed: DAWARICH_API_KEY is required for Dawarich 1.3.4 API upload."
         current_app.logger.error(msg)
         flash(msg, 'error')
         status_cache.update({'status': False, 'timestamp': time.time(), 'message': msg, 'version': None})
         return False
 
-    login_url = f'{host}/users/sign_in'
-    sess = requests.Session()
-
+    imports_url = f'{host}/api/v1/imports'
     try:
-        page = sess.get(login_url, timeout=10)
-        page.raise_for_status()
-        soup = BeautifulSoup(page.text, 'html.parser')
-        token_element = soup.find('input', {'name': 'authenticity_token'})
-        if not token_element:
-            raise ValueError("Could not find CSRF token on Dawarich login page.")
-        token = token_element['value']
-
-        data = {
-            'user[email]': user,
-            'user[password]': pwd,
-            'authenticity_token': token
-        }
-        resp = sess.post(login_url, data=data, timeout=10)
+        resp = requests.get(
+            imports_url,
+            params={'api_key': api_key, 'per_page': 1},
+            timeout=10,
+        )
         resp.raise_for_status()
-
-        if "Invalid Email or password." in resp.text:
-            raise ValueError("Invalid Dawarich credentials.")
-
-        # --- Find Dawarich Version ---
-        soup_dashboard = BeautifulSoup(resp.text, 'html.parser')
-        version_link = soup_dashboard.find('a', href="https://github.com/Freika/dawarich/releases/latest")
-        dawarich_version = None
-        if version_link:
-            version_span = version_link.find('span')
-            if version_span:
-                dawarich_version = version_span.text.strip().rstrip(' !').strip()
-
-        settings = UserSettings.query.first()
-        if settings and settings.ignore_safe_dawarich_versions:
-            current_app.logger.warning("Dawarich safe version check is being ignored by user setting.")
-        else:
-            safe_versions = current_app.config.get('SAFE_VERSIONS', [])
-            if not dawarich_version:
-                msg = "Could not determine Dawarich version. Aborting as a precaution."
-                current_app.logger.error(msg)
-                flash(msg, 'error')
-                status_cache.update({'status': False, 'timestamp': time.time(), 'message': msg, 'version': None})
-                return False
-
-            if dawarich_version not in safe_versions:
-                msg = f"Dawarich version {dawarich_version} is not in the list of safe versions: {safe_versions}"
-                current_app.logger.error(msg)
-                flash(msg, 'error')
-                status_cache.update({'status': False, 'timestamp': time.time(), 'message': msg, 'version': dawarich_version})
-                return False
-
-        current_app.logger.info(f"Dawarich connection check successful. Version: {dawarich_version}")
-        status_cache.update({'status': True, 'timestamp': time.time(), 'message': '', 'version': dawarich_version})
+        current_app.logger.info("Dawarich API connection check successful.")
+        status_cache.update({'status': True, 'timestamp': time.time(), 'message': '', 'version': '1.3.4+'})
         return True
-
+    except requests.exceptions.HTTPError as e:
+        status_code = e.response.status_code if e.response is not None else None
+        if status_code == 404:
+            msg = (
+                "Dawarich API import endpoint not found. DAWARICH_API_KEY upload requires "
+                "Dawarich 1.3.4 with the /api/v1/imports endpoint."
+            )
+        elif status_code in (401, 403):
+            msg = "Dawarich API connection failed: invalid API key or API access denied."
+        else:
+            msg = f"Dawarich API connection failed: HTTP error - {e}"
+        current_app.logger.error(msg)
+        flash(msg, 'error')
+        status_cache.update({'status': False, 'timestamp': time.time(), 'message': msg, 'version': None})
+        return False
     except requests.exceptions.RequestException as e:
-        msg = f"Dawarich connection failed: Network error - {e}"
+        msg = f"Dawarich API connection failed: Network error - {e}"
         current_app.logger.error(msg)
-        flash(msg, 'error')
-        status_cache.update({'status': False, 'timestamp': time.time(), 'message': msg, 'version': None})
-        return False
-    except ValueError as e:
-        msg = f"Dawarich connection failed: {e}"
-        current_app.logger.error(msg)
-        flash(msg, 'error')
-        status_cache.update({'status': False, 'timestamp': time.time(), 'message': msg, 'version': None})
-        return False
-    except Exception as e:
-        msg = f"Dawarich connection failed: An unexpected error occurred - {e}"
-        current_app.logger.error(msg, exc_info=True)
         flash(msg, 'error')
         status_cache.update({'status': False, 'timestamp': time.time(), 'message': msg, 'version': None})
         return False
@@ -349,9 +271,9 @@ def garmin_interactive_login(email, password):
             }
 
         # No MFA needed — save tokens
-        gc.garth.dump(tokenstore)
+        gc.client.dump(tokenstore)
         with open(GARMIN_TOKENSTORE_B64, "w") as f:
-            f.write(gc.garth.dumps())
+            f.write(gc.client.dumps())
         current_app.logger.info("Garmin interactive login successful (no MFA).")
         return {
             "status": "success",
@@ -390,9 +312,9 @@ def garmin_complete_mfa(mfa_code):
         gc.resume_login(client_state, mfa_code)
 
         # Save tokens
-        gc.garth.dump(tokenstore)
+        gc.client.dump(tokenstore)
         with open(GARMIN_TOKENSTORE_B64, "w") as f:
-            f.write(gc.garth.dumps())
+            f.write(gc.client.dumps())
 
         # Clear MFA state
         current_app.config.pop('_GARMIN_MFA_STATE', None)
@@ -404,7 +326,7 @@ def garmin_complete_mfa(mfa_code):
             "display_name": gc.display_name or gc.full_name or "Garmin User",
         }
 
-    except GarthHTTPError as e:
+    except HTTPError as e:
         error_str = str(e)
         if "429" in error_str:
             current_app.config.pop('_GARMIN_MFA_STATE', None)
@@ -461,7 +383,7 @@ def init_garmin():
         gc = Garmin()
         gc.login(tokenstore)
         return gc
-    except (FileNotFoundError, GarthHTTPError, GarminConnectAuthenticationError):
+    except (FileNotFoundError, HTTPError, GarminConnectAuthenticationError):
         pass  # Fall through to credential login
 
     # 2. Try env-var credentials
@@ -479,9 +401,9 @@ def init_garmin():
                 "MFA is required for this Garmin account. "
                 "Please log in via the Settings page in the web UI."
             )
-        gc.garth.dump(tokenstore)
+        gc.client.dump(tokenstore)
         with open(GARMIN_TOKENSTORE_B64, "w") as f:
-            f.write(gc.garth.dumps())
+            f.write(gc.client.dumps())
         gc.login(tokenstore)
     except (RuntimeError, ValueError):
         raise
@@ -600,215 +522,13 @@ def submit_location_data_via_api(gpx_path: str) -> bool:
 
 
 def submit_location_data(gpx_path: str, source: str = "gpx") -> bool:
-    """
-    1) Log in and get CSRF token
-    2) Fetch the import form to get the direct-upload URL and import CSRF token
-    3) Direct-upload the GPX file blob metadata
-    4) Upload the actual GPX file
-    5) Submit the import form with the signed_id of the uploaded blob
-    6) Check if upload was successful
-    """
+    """Upload a GPX file to Dawarich 1.3.4 using the API-key import endpoint."""
     if not check_dawarich_connection():
         current_app.logger.error("submit_location_data: Aborting due to failed Dawarich connection check.")
         return False
 
-    if current_app.config.get('DAWARICH_API_KEY'):
-        return submit_location_data_via_api(gpx_path)
-
-    current_app.logger.info(f"submit_location_data: Starting import for {gpx_path}, source={source}")
-    # -- 1) LOGIN ---------------------------------------------------------
-    host  = (current_app.config.get('DAWARICH_HOST') or '').rstrip('/')
-    login_url =f'{host}/users/sign_in'
-
-    user = current_app.config.get('DAWARICH_EMAIL') 
-    pwd  = current_app.config.get('DAWARICH_PASSWORD')
-
-    sess = requests.Session()
-    # first GET login page to retrieve CSRF token
-    page = sess.get(login_url)
-    page.raise_for_status()
-    soup = BeautifulSoup(page.text, 'html.parser')
-    token = soup.find('input', {'name': 'authenticity_token'})['value']
-    current_app.logger.debug(f"submit_location_data: Step 1: Fetched login CSRF token={token[:8]}…")
-
-    # now POST credentials + token
-    data = {
-        'user[email]': user,
-        'user[password]': pwd,
-        'authenticity_token': token
-    }
-    current_app.logger.debug(f"submit_location_data: Step 1: POSTing login credentials to {login_url}")
-    resp = sess.post(login_url, data=data)
-    resp.raise_for_status()
-    current_app.logger.info(f"submit_location_data: Step 1: Login successful to {login_url}")
-    current_app.logger.debug(f"submit_location_data: Step 1: Session cookies after login: {sess.cookies.get_dict()}")
-
-    # -- 2) IMPORT FORM ---------------------------------------------------
-    form_url = f'{host}/imports/new'
-    resp = sess.get(form_url); resp.raise_for_status()
-    current_app.logger.debug(f"submit_location_data: Step 2: GET import form {form_url} status={resp.status_code}")
-    soup2 = BeautifulSoup(resp.text, 'html.parser')
-
-    # Try to get CSRF token from meta tag first, then fall back to input field
-    import_csrf_meta_tag = soup2.find('meta', {'name': 'csrf-token'})
-    if import_csrf_meta_tag and import_csrf_meta_tag.get('content'):
-        import_token = import_csrf_meta_tag['content']
-        current_app.logger.debug("submit_location_data: Step 2: Extracted import CSRF token from meta tag.")
-    else:
-        import_token_element = soup2.find('input', {'name':'authenticity_token'})
-        if not import_token_element:
-            current_app.logger.error("submit_location_data: Step 2: Could not find authenticity_token (meta or input) on import page.")
-            raise RuntimeError("Could not find authenticity_token (meta or input) on import page.")
-        import_token = import_token_element['value']
-        current_app.logger.debug("submit_location_data: Step 2: Extracted import CSRF token from input field.")
-
-    # Find the upload form — Dawarich renamed the Stimulus controller:
-    #   Old: data-controller="direct-upload"  data-direct-upload-url-value="..."
-    #   New: data-controller="upload"         data-upload-url-value="..."
-    upload_form = (
-        soup2.find('form', {'data-controller': 'upload'})
-        or soup2.find('form', {'data-controller': 'direct-upload'})
-    )
-    if not upload_form:
-        current_app.logger.error(
-            "submit_location_data: Step 2: Could not find upload form on import page. "
-            "Your Dawarich version may be incompatible."
-        )
-        raise RuntimeError("Could not find upload form on Dawarich import page.")
-
-    direct_upload_url = (
-        upload_form.get('data-upload-url-value')
-        or upload_form.get('data-direct-upload-url-value')
-    )
-    if not direct_upload_url:
-        current_app.logger.error(
-            "submit_location_data: Step 2: Upload form found but no direct-upload URL attribute. "
-            f"Form attributes: {list(upload_form.attrs.keys())}"
-        )
-        raise RuntimeError("Could not find direct-upload URL on Dawarich import form.")
-
-    current_app.logger.info(f"submit_location_data: Step 2: Import CSRF token={import_token[:8]}…, Direct-upload URL={direct_upload_url}")
-
-    # -- 3) DIRECT UPLOAD BLOB META ---------------------------------------
-    filename     = os.path.basename(gpx_path)
-    content_type = mimetypes.guess_type(filename)[0] or 'application/octet-stream'
-
-    # load file bytes for size & checksum
-    with open(gpx_path, 'rb') as f:
-        file_data = f.read()
-    byte_size = len(file_data)
-    checksum  = base64.b64encode(hashlib.md5(file_data).digest()).decode()
-    blob_json = {
-        'blob': {
-            'filename': filename,
-            'content_type': content_type,
-            'byte_size': byte_size,
-            'checksum':  checksum
-        }
-    }
-
-    # Derive Origin and Referer from form_url for headers
-    parsed_form_url_step3 = requests.utils.urlparse(form_url)
-    origin_step3 = f"{parsed_form_url_step3.scheme}://{parsed_form_url_step3.netloc}"
-
-    headers_step3 = {
-        'Content-Type': 'application/json',
-        'Accept':       'application/json',
-        'X-CSRF-Token': import_token, # Use the token from the import form
-        'X-Requested-With': 'XMLHttpRequest',
-        'Referer': form_url,
-        'Origin': origin_step3,
-        'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/115.0'
-    }
-    current_app.logger.debug(f"submit_location_data: Step 3: Blob metadata payload: {blob_json}")
-    current_app.logger.debug(f"submit_location_data: Step 3: Headers for blob metadata POST: {headers_step3}")
-    current_app.logger.debug(f"submit_location_data: Step 3: POSTing blob metadata to {direct_upload_url}")
-    r = sess.post(direct_upload_url, json=blob_json, headers=headers_step3)
-    if not r.ok:
-        current_app.logger.error(
-            f"submit_location_data: Step 3: Direct-upload metadata POST failed: {r.status_code} - {r.text[:500]}"
-        )
-    r.raise_for_status()
-    info      = r.json()
-    signed_id = info['signed_id']
-    current_app.logger.info(f"submit_location_data: Step 3: Direct-upload metadata POST successful. Signed ID: {signed_id[:15]}…")
-    current_app.logger.debug(f"submit_location_data: Step 3: Full direct upload info: {info}")
-
-
-    # -- 4) UPLOAD ACTUAL FILE --------------------------------------------
-    upload_url = info['direct_upload']['url']
-    upload_headers = info['direct_upload']['headers']
-
-    current_app.logger.debug(f"submit_location_data: Step 4: Uploading file to {upload_url}")
-    current_app.logger.debug(f"submit_location_data: Step 4: Headers for file PUT: {upload_headers}")
-    with open(gpx_path, 'rb') as f:
-        r = sess.put(upload_url, data=f, headers=upload_headers)
-    if not r.ok:
-        current_app.logger.error(
-            f"submit_location_data: Step 4: File PUT failed: {r.status_code} - {r.text[:500]}"
-        )
-    r.raise_for_status()
-    current_app.logger.info(f"submit_location_data: Step 4: File PUT to {upload_url} successful.")
-
-    # -- 5) SUBMIT IMPORT -------------------------------------------------
-    import_url = f'{host}/imports'
-    form_data_step5 = [
-        ('authenticity_token', import_token), # This is the CSRF token for the form
-        ('import[source]',     source),
-        ('import[files][]',    signed_id)
-    ]
-
-    origin_step5 = origin_step3
-    
-    headers_step5 = {
-        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
-        'Referer': form_url, 
-        'Origin': origin_step5,
-        'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/115.0'
-    }
-    
-    current_app.logger.debug(f"submit_location_data: Step 5: Form data for final import: {form_data_step5}")
-    current_app.logger.debug(f"submit_location_data: Step 5: Headers for final import POST: {headers_step5}")
-    current_app.logger.debug(f"submit_location_data: Step 5: POSTing final import form to {import_url}")
-    # Add files={} to ensure Content-Type is multipart/form-data, matching browser behavior for forms with enctype="multipart/form-data"
-    resp = sess.post(import_url, data=form_data_step5, headers=headers_step5, files={}) 
-    
-    if not resp.ok:
-        current_app.logger.error(
-            f"submit_location_data: Step 5: Final import POST failed: {resp.status_code} - {resp.text[:500]}"
-        )
-    resp.raise_for_status()
-    current_app.logger.info(f"submit_location_data: Step 5: Final import POST to {import_url} successful (status={resp.status_code}).")
-
-    # -- 6) CHECK IF UPLOAD WAS SUCCESSFUL --------------------------------
-    # After a successful import, we should be on the /imports page.
-    # We'll check if the filename appears in the list of imports.
-    current_app.logger.info(f"submit_location_data: Step 6: Verifying presence of {filename} on imports page.")
-    soup_imports = BeautifulSoup(resp.text, 'html.parser')
-    
-    # Find all links that point to an import detail page
-    import_links = soup_imports.find_all('a', href=lambda href: href and href.startswith('/imports/'))
-    
-    found = False
-    for link in import_links:
-        if link.text.strip() == filename:
-            found = True
-            break
-            
-    if found:
-        current_app.logger.info(f"submit_location_data: Step 6: Verification successful. Found {filename} in imports list.")
-        
-        # Check settings to see if we should delete the file
-        settings = UserSettings.query.first()
-        if settings and settings.delete_old_gpx:
-            try:
-                os.remove(gpx_path)
-                current_app.logger.info(f"submit_location_data: Deleted successfully uploaded file as per user setting: {gpx_path}")
-            except OSError as e:
-                current_app.logger.error(f"submit_location_data: Failed to delete file {gpx_path}: {e}", exc_info=True)
-
-        current_app.logger.info(f"submit_location_data: Successfully imported {filename} (blob signed_id: {signed_id[:15]}…).")
-        return True
-    else:
-        current_app.logger.error(f"submit_location_data: Step 6: Verification FAILED. Did not find {filename} in imports list after successful upload POST.")
+    if not current_app.config.get('DAWARICH_API_KEY'):
+        current_app.logger.error("submit_location_data: DAWARICH_API_KEY is required for Dawarich 1.3.4 API upload.")
         return False
+
+    return submit_location_data_via_api(gpx_path)

--- a/utils.py
+++ b/utils.py
@@ -123,8 +123,23 @@ def check_dawarich_connection(force_check=False):
             current_app.logger.info("Dawarich API connection check successful.")
             status_cache.update({'status': True, 'timestamp': time.time(), 'message': '', 'version': None})
             return True
+        except requests.exceptions.HTTPError as e:
+            status_code = e.response.status_code if e.response is not None else None
+            if status_code == 404:
+                msg = (
+                    "Dawarich API import endpoint not found. DAWARICH_API_KEY upload requires "
+                    "Dawarich 1.3.4 or newer; use legacy email/password upload on older Dawarich versions."
+                )
+            elif status_code in (401, 403):
+                msg = "Dawarich API connection failed: invalid API key or API access denied."
+            else:
+                msg = f"Dawarich API connection failed: HTTP error - {e}"
+            current_app.logger.error(msg)
+            flash(msg, 'error')
+            status_cache.update({'status': False, 'timestamp': time.time(), 'message': msg, 'version': None})
+            return False
         except requests.exceptions.RequestException as e:
-            msg = f"Dawarich API connection failed: Network or authentication error - {e}"
+            msg = f"Dawarich API connection failed: Network error - {e}"
             current_app.logger.error(msg)
             flash(msg, 'error')
             status_cache.update({'status': False, 'timestamp': time.time(), 'message': msg, 'version': None})

--- a/utils.py
+++ b/utils.py
@@ -99,12 +99,39 @@ def check_dawarich_connection(force_check=False):
                 flash(status_cache['message'], 'error')
             return status_cache['status']
 
-    host = current_app.config.get('DAWARICH_HOST')
+    host = (current_app.config.get('DAWARICH_HOST') or '').rstrip('/')
     user = current_app.config.get('DAWARICH_EMAIL')
     pwd = current_app.config.get('DAWARICH_PASSWORD')
+    api_key = current_app.config.get('DAWARICH_API_KEY')
 
-    if not all([host, user, pwd]):
-        msg = "Dawarich connection failed: Host, email, or password not configured."
+    if not host:
+        msg = "Dawarich connection failed: Host not configured."
+        current_app.logger.error(msg)
+        flash(msg, 'error')
+        status_cache.update({'status': False, 'timestamp': time.time(), 'message': msg, 'version': None})
+        return False
+
+    if api_key:
+        imports_url = f'{host}/api/v1/imports'
+        try:
+            resp = requests.get(
+                imports_url,
+                params={'api_key': api_key, 'per_page': 1},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            current_app.logger.info("Dawarich API connection check successful.")
+            status_cache.update({'status': True, 'timestamp': time.time(), 'message': '', 'version': None})
+            return True
+        except requests.exceptions.RequestException as e:
+            msg = f"Dawarich API connection failed: Network or authentication error - {e}"
+            current_app.logger.error(msg)
+            flash(msg, 'error')
+            status_cache.update({'status': False, 'timestamp': time.time(), 'message': msg, 'version': None})
+            return False
+
+    if not all([user, pwd]):
+        msg = "Dawarich connection failed: Email or password not configured. Set DAWARICH_API_KEY for OIDC/API upload."
         current_app.logger.error(msg)
         flash(msg, 'error')
         status_cache.update({'status': False, 'timestamp': time.time(), 'message': msg, 'version': None})
@@ -516,6 +543,47 @@ def download_activities(startdate: datetime.datetime,
 
 
 
+def submit_location_data_via_api(gpx_path: str) -> bool:
+    """Upload a GPX file using Dawarich's API-key import endpoint (Dawarich 1.3.4+)."""
+    host = (current_app.config.get('DAWARICH_HOST') or '').rstrip('/')
+    api_key = current_app.config.get('DAWARICH_API_KEY')
+
+    if not host or not api_key:
+        current_app.logger.error("submit_location_data_via_api: Dawarich host or API key is not configured.")
+        return False
+
+    import_url = f'{host}/api/v1/imports'
+    filename = os.path.basename(gpx_path)
+    content_type = mimetypes.guess_type(filename)[0] or 'application/octet-stream'
+
+    current_app.logger.info(f"submit_location_data_via_api: Uploading {filename} to Dawarich API.")
+    with open(gpx_path, 'rb') as file_handle:
+        files = {'file': (filename, file_handle, content_type)}
+        resp = requests.post(
+            import_url,
+            params={'api_key': api_key},
+            files=files,
+            timeout=60,
+        )
+
+    if not resp.ok:
+        current_app.logger.error(
+            f"submit_location_data_via_api: API import failed: {resp.status_code} - {resp.text[:500]}"
+        )
+        return False
+
+    settings = UserSettings.query.first()
+    if settings and settings.delete_old_gpx:
+        try:
+            os.remove(gpx_path)
+            current_app.logger.info(f"submit_location_data_via_api: Deleted successfully uploaded file as per user setting: {gpx_path}")
+        except OSError as e:
+            current_app.logger.error(f"submit_location_data_via_api: Failed to delete file {gpx_path}: {e}", exc_info=True)
+
+    current_app.logger.info(f"submit_location_data_via_api: Successfully submitted {filename} to Dawarich API.")
+    return True
+
+
 def submit_location_data(gpx_path: str, source: str = "gpx") -> bool:
     """
     1) Log in and get CSRF token
@@ -529,9 +597,12 @@ def submit_location_data(gpx_path: str, source: str = "gpx") -> bool:
         current_app.logger.error("submit_location_data: Aborting due to failed Dawarich connection check.")
         return False
 
+    if current_app.config.get('DAWARICH_API_KEY'):
+        return submit_location_data_via_api(gpx_path)
+
     current_app.logger.info(f"submit_location_data: Starting import for {gpx_path}, source={source}")
     # -- 1) LOGIN ---------------------------------------------------------
-    host  = current_app.config.get('DAWARICH_HOST')
+    host  = (current_app.config.get('DAWARICH_HOST') or '').rstrip('/')
     login_url =f'{host}/users/sign_in'
 
     user = current_app.config.get('DAWARICH_EMAIL') 


### PR DESCRIPTION
## Summary
- add `DAWARICH_API_KEY` support for Dawarich 1.3.4+ API imports
- use `POST /api/v1/imports?api_key=...` for GPX uploads when an API key is configured, avoiding the browser login/CSRF flow that breaks with OIDC-only Dawarich
- keep the existing browser upload flow as a fallback when no API key is configured
- document the new env var and add tests for API upload + API-key connection checks

## Test Plan
- `python -m unittest discover -s tests -v`
- `pytest -q`
- `python -m py_compile app.py index.py models.py utils.py tests/test_dawarich_api_upload.py`

Closes #11
